### PR TITLE
Update the near-cli-version to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "dotenv": "^8.2.0",
-    "near-cli": "^1.4.0",
+    "near-cli": "^2.2.0",
     "near-sdk-as": "^2.1.0",
     "user-home": "^2.0.0"
   }


### PR DESCRIPTION
when running Yarn deploy. it gives always an error like the following 
```
`$ near dev-deploy --wasmFile="./contract.wasm"
Starting deployment. Account id: dev-1637914848513-1635411, node: https://rpc.testnet.near.org, helper: https://helper.testnet.near.org, file: ./contract.wasm
An error occured
Error: Can not sign transactions for account dev-1637914848513-1635411 on network default, no matching key pair found in InMemorySigner(MergeKeyStore(UnencryptedFileSystemKeyStore(/home/rasha/.near-credentials), UnencryptedFileSystemKeyStore(/home/rasha/collection-examples-as-4/neardev))).
error Command failed with exit code 1
```
then when I update the near-cli-version to the current one which is 2.2.0 it works fine. here is the link to the result 
 https://explorer.testnet.near.org/transactions/28HvBEgBwhitabWBAXLqNaZLUvmJnAe6TYuueb9kMZng

